### PR TITLE
fix(browse): resize data tab right section

### DIFF
--- a/src/components/browse-tab/BrowseTab.tsx
+++ b/src/components/browse-tab/BrowseTab.tsx
@@ -57,6 +57,7 @@ function BrowseTab() {
             id="dataPanel"
             defaultSize={dataPanelSize}
             onResize={setDataPanelSize}
+            className="min-w-0"
           >
             <div
               className="flex h-full min-h-0 flex-col border-l"
@@ -67,25 +68,23 @@ function BrowseTab() {
             </div>
           </ResizablePanel>
 
-          <div className="hidden md:contents">
-            <ResizableHandle withHandle />
+          <ResizableHandle className="hidden md:flex" withHandle />
 
-            <ResizablePanel
-              id="schemaPanel"
-              defaultSize={schemaPanelSize}
-              onResize={setSchemaPanelSize}
-              className="relative"
+          <ResizablePanel
+            id="schemaPanel"
+            defaultSize={schemaPanelSize}
+            onResize={setSchemaPanelSize}
+            className="relative hidden min-w-0 md:block"
+          >
+            <SchemaTreePanel />
+            <div
+              className={`bg-background absolute inset-0 z-40 ${isEditing ? "block" : "hidden"}`}
             >
-              <SchemaTreePanel />
-              <div
-                className={`bg-background absolute inset-0 z-40 ${isEditing ? "block" : "hidden"}`}
-              >
-                <section className="bg-primary/5 h-full">
-                  <EditSection />
-                </section>
-              </div>
-            </ResizablePanel>
-          </div>
+              <section className="bg-primary/5 h-full">
+                <EditSection />
+              </section>
+            </div>
+          </ResizablePanel>
         </ResizablePanelGroup>
 
         <div className="md:hidden">

--- a/src/components/structure-tab/SchemaTreePanel.tsx
+++ b/src/components/structure-tab/SchemaTreePanel.tsx
@@ -2,7 +2,7 @@ import SchemaTree from "./SchemaTree";
 
 export default function SchemaTreePanel() {
   return (
-    <div className="h-full overflow-hidden">
+    <div className="h-full min-w-0 overflow-hidden">
       <div className="h-full overflow-y-auto">
         <SchemaTree />
       </div>


### PR DESCRIPTION

This PR fixes the Browse Data split-pane layout so the right-side schema section resizes correctly again.

Close #128 

## What Changed
- Made the left and right browse panels direct siblings in the resizable group.
- Added `min-w-0` to both resizable panels.
- Added `min-w-0` to the schema tree panel wrapper.

